### PR TITLE
Exposing enableInteractivity config to Grails plugin

### DIFF
--- a/src/groovy/org/grails/plugins/google/visualization/option/core/BarCoreChartConfigOption.groovy
+++ b/src/groovy/org/grails/plugins/google/visualization/option/core/BarCoreChartConfigOption.groovy
@@ -40,7 +40,8 @@ enum BarCoreChartConfigOption {
     TITLE_TEXT_STYLE("titleTextStyle", [DataType.OBJECT]),
     TOOLTIP_TEXT_STYLE("tooltipTextStyle", [DataType.OBJECT]),
     V_AXIS("vAxis", [DataType.OBJECT]),
-    WIDTH("width", [DataType.NUMBER])
+    WIDTH("width", [DataType.NUMBER]),
+    ENABLE_INTERACTIVITY("enableInteractivity", [DataType.BOOLEAN])
 
     static final Map configOptions
 


### PR DESCRIPTION
We were missing the config parameter `enableInteractivity` in one of our grails projects to disable the tooltip on hovering a bar. Hopefully it can be included into a soon to be released version of the plugin so that we don't need to roll our own version of the plugin?
