### PR TITLE
Added bar attribute to ComboCoreChart

### DIFF
--- a/src/groovy/org/grails/plugins/google/visualization/option/core/ComboCoreChartConfigOption.groovy
+++ b/src/groovy/org/grails/plugins/google/visualization/option/core/ComboCoreChartConfigOption.groovy
@@ -25,6 +25,7 @@ enum ComboCoreChartConfigOption {
     AREA_OPACITY("areaOpacity", [DataType.NUMBER]),
     AXIS_TITLES_POSITION("axisTitlesPosition", [DataType.STRING]),
     BACKGROUND_COLOR("backgroundColor", [DataType.STRING, DataType.OBJECT]),
+    BAR("bar", [DataType.OBJECT]),
     CHART_AREA("chartArea", [DataType.OBJECT]),
     COLORS("colors", [DataType.ARRAY]),
     CURVE_TYPE("curveType", [DataType.STRING]),


### PR DESCRIPTION
The bar attribute was missing from the ComboCoreChart so I went ahead 
and added it. Accepts an object with the key groupWidth which has a
value defined in the documentation as -

The width of a group of bars, specified in either of these formats:
 \* Pixels (e.g. 50).
 \* Percentage of the available width for each group (e.g. '20%'),
where '100%' means that groups have no space between them.
