### PR TITLE
Added missing "bar" attribute to several charts

### DIFF
--- a/src/groovy/org/grails/plugins/google/visualization/option/core/BarCoreChartConfigOption.groovy
+++ b/src/groovy/org/grails/plugins/google/visualization/option/core/BarCoreChartConfigOption.groovy
@@ -23,6 +23,7 @@ import org.grails.plugins.google.visualization.data.DataType
  */
 enum BarCoreChartConfigOption {
     AXIS_TITLES_POSITION("axisTitlesPosition", [DataType.STRING]),
+    BAR("bar", [DataType.OBJECT]),
     BACKGROUND_COLOR("backgroundColor", [DataType.STRING, DataType.OBJECT]),
     CHART_AREA("chartArea", [DataType.OBJECT]),
     COLORS("colors", [DataType.ARRAY]),

--- a/src/groovy/org/grails/plugins/google/visualization/option/core/CandlestickCoreChartConfigOption.groovy
+++ b/src/groovy/org/grails/plugins/google/visualization/option/core/CandlestickCoreChartConfigOption.groovy
@@ -24,6 +24,7 @@ import org.grails.plugins.google.visualization.data.DataType
 enum CandlestickCoreChartConfigOption {
     AXIS_TITLES_POSITION("axisTitlesPosition", [DataType.STRING]),
     BACKGROUND_COLOR("backgroundColor", [DataType.STRING, DataType.OBJECT]),
+    BAR("bar", [DataType.OBJECT]),
     CHART_AREA("chartArea", [DataType.OBJECT]),
     COLORS("colors", [DataType.ARRAY]),
     ENABLE_INTERACTIVITY("enableInteractivity", [DataType.BOOLEAN]),

--- a/src/groovy/org/grails/plugins/google/visualization/option/core/ColumnCoreChartConfigOption.groovy
+++ b/src/groovy/org/grails/plugins/google/visualization/option/core/ColumnCoreChartConfigOption.groovy
@@ -25,6 +25,7 @@ enum ColumnCoreChartConfigOption {
     AREA_OPACITY("areaOpacity", [DataType.NUMBER]),
     AXIS_TITLES_POSITION("axisTitlesPosition", [DataType.STRING]),
     BACKGROUND_COLOR("backgroundColor", [DataType.STRING, DataType.OBJECT]),
+    BAR("bar", [DataType.OBJECT]),
     CHART_AREA("chartArea", [DataType.OBJECT]),
     COLORS("colors", [DataType.ARRAY]),
     ENABLE_INTERACTIVITY("enableInteractivity", [DataType.BOOLEAN]),

--- a/src/groovy/org/grails/plugins/google/visualization/option/core/ComboCoreChartConfigOption.groovy
+++ b/src/groovy/org/grails/plugins/google/visualization/option/core/ComboCoreChartConfigOption.groovy
@@ -25,6 +25,7 @@ enum ComboCoreChartConfigOption {
     AREA_OPACITY("areaOpacity", [DataType.NUMBER]),
     AXIS_TITLES_POSITION("axisTitlesPosition", [DataType.STRING]),
     BACKGROUND_COLOR("backgroundColor", [DataType.STRING, DataType.OBJECT]),
+    BAR("bar", [DataType.OBJECT]),
     CHART_AREA("chartArea", [DataType.OBJECT]),
     COLORS("colors", [DataType.ARRAY]),
     CURVE_TYPE("curveType", [DataType.STRING]),


### PR DESCRIPTION
I've added the "bar" attribute to the four charts I could find which used it.

Name
bar.groupWidth

Type
number or string

Default
The golden ratio, approximately '61.8%'.

Description
The width of a group of bars, specified in either of these formats:
Pixels (e.g. 50).
Percentage of the available width for each group (e.g. '20%'), where '100%' means that groups have no space between them.
