### PR TITLE
Add in feature to use a callback with the jsapi for calling google.load

### DIFF
--- a/grails-app/taglib/org/grails/plugins/google/visualization/GoogleVisualizationTagLib.groovy
+++ b/grails-app/taglib/org/grails/plugins/google/visualization/GoogleVisualizationTagLib.groovy
@@ -23,10 +23,18 @@ class GoogleVisualizationTagLib {
     static namespace = "gvisualization"
     static final PLUGIN_NAME = 'google-visualization'
     static final VISUALIZATION_JAVASCRIPT_TEMPLATE = '/visualization_javascript'
-    final BASIC_ATTRIBUTES = ['name', 'version', 'elementId', 'dynamicLoading', 'language', 'columns', 'data'] as Set
+    final BASIC_ATTRIBUTES = ['callback', 'name', 'version', 'elementId', 'dynamicLoading', 'language', 'columns', 'data'] as Set
 
     def apiImport = { attrs, body ->
-        out << '<script type="text/javascript" src="http://www.google.com/jsapi"></script>'
+        out << '<script type="text/javascript" src="//www.google.com/jsapi'
+        if (attrs.callback && attrs.key) {
+            out << "?key=${attrs.key}&callback=${attrs.callback}"
+        } else if (attrs.callback) {
+            out << "?callback=${attrs.callback}"
+        } else if (attrs.key) {
+            out << "?key=${attrs.key}"
+        }
+        out << '"></script>'
     }
 
     def pieChart = { attrs, body ->

--- a/grails-app/views/_visualization_javascript.gsp
+++ b/grails-app/views/_visualization_javascript.gsp
@@ -1,9 +1,14 @@
 <%@ page import="org.apache.commons.lang.StringUtils" %>
 <g:set var="functionName" value="draw${StringUtils.capitalize(visualizationData.name)}"/>
 <script type="text/javascript">
-    google.load('visualization', '<%=visualizationData.version%>', {'packages': ['<%=visualizationData.visualization.packageName%>']<g:if test="${visualizationData.dynamicLoading}">, 'callback': <%=functionName%></g:if><g:if test="${visualizationData.language}">, 'language': '<%=visualizationData.language%>'</g:if>});
-    <g:if test="${!visualizationData.dynamicLoading}">google.setOnLoadCallback(<%=functionName%>);</g:if>
-    
+    <g:if test="${visualizationData.callback}">
+    function <%=visualizationData.callback%>() {
+    </g:if>
+        google.load('visualization', '<%=visualizationData.version%>', {'packages': ['<%=visualizationData.visualization.packageName%>']<g:if test="${visualizationData.dynamicLoading}">, 'callback': <%=functionName%></g:if><g:if test="${visualizationData.language}">, 'language': '<%=visualizationData.language%>'</g:if>});
+        <g:if test="${!visualizationData.dynamicLoading}">google.setOnLoadCallback(<%=functionName%>);</g:if>
+    <g:if test="${visualizationData.callback}">
+    }
+    </g:if>
     function <%=functionName%>() {
         <%=visualizationData.name%>_data = new google.visualization.DataTable();
         <g:each var="column" in="${visualizationData.columns}">
@@ -12,7 +17,7 @@
         <g:each var="row" in="${visualizationData.rows}">
         <%=visualizationData.name%>_data.addRow(<%=row%>);
         </g:each>
-      
+
         <%=visualizationData.name%> = new <%=visualizationData.visualization.object%>(document.getElementById('<%=visualizationData.elementId%>'));
 
         <g:render template="/formatter" model="[visualizationData: visualizationData]" plugin="google-visualization"/>
@@ -20,7 +25,7 @@
         <g:each var="beforeDrawEvent" in="${visualizationData.beforeDrawEvents}">
         google.visualization.events.addListener(<%=visualizationData.name%>, '<%=beforeDrawEvent.key%>', <%=beforeDrawEvent.value%>);
         </g:each>
-        
+
         <%=visualizationData.name%>.draw(<%=visualizationData.name%>_data, <%=visualizationData.options%>);
 
         <g:each var="afterDrawEvent" in="${visualizationData.afterDrawEvents}">

--- a/src/groovy/org/grails/plugins/google/visualization/GoogleVisualizationBuilder.groovy
+++ b/src/groovy/org/grails/plugins/google/visualization/GoogleVisualizationBuilder.groovy
@@ -33,10 +33,16 @@ class GoogleVisualizationBuilder extends VisualizationBuilder {
     static final Log log = LogFactory.getLog(GoogleVisualizationBuilder)
     final DEFAULT_NAME = 'visualization'
     final DEFAULT_VERSION = '1'
+    final DEFAULT_CALLBACK = null
 
     @Override
     def buildName() {
         visualizationData.name = attrs.name ?: DEFAULT_NAME
+    }
+
+    @Override
+    def buildCallback() {
+        visualizationData.callback = attrs.callback ?: DEFAULT_CALLBACK
     }
 
     @Override
@@ -57,7 +63,7 @@ class GoogleVisualizationBuilder extends VisualizationBuilder {
     @Override
     def buildLanguage() {
         if(attrs.language) {
-            visualizationData.language = attrs.language 
+            visualizationData.language = attrs.language
         }
     }
 
@@ -204,6 +210,6 @@ class GoogleVisualizationBuilder extends VisualizationBuilder {
 
     @Override
     def buildFormatters() {
-        visualizationData.formatters = attrs.formatters 
+        visualizationData.formatters = attrs.formatters
     }
 }

--- a/src/groovy/org/grails/plugins/google/visualization/VisualizationBuilder.groovy
+++ b/src/groovy/org/grails/plugins/google/visualization/VisualizationBuilder.groovy
@@ -29,6 +29,7 @@ abstract class VisualizationBuilder {
     }
 
     abstract buildName()
+    abstract buildCallback()
     abstract buildVersion()
     abstract buildElementId()
     abstract buildDynamicLoading()

--- a/src/groovy/org/grails/plugins/google/visualization/VisualizationData.groovy
+++ b/src/groovy/org/grails/plugins/google/visualization/VisualizationData.groovy
@@ -22,6 +22,7 @@ package org.grails.plugins.google.visualization
 class VisualizationData {
     final visualization
     def version
+    def callback
     def name
     def elementId
     def dynamicLoading

--- a/src/groovy/org/grails/plugins/google/visualization/VisualizationDataDirector.groovy
+++ b/src/groovy/org/grails/plugins/google/visualization/VisualizationDataDirector.groovy
@@ -29,6 +29,7 @@ class VisualizationDataDirector {
     def constructVisualizationData(attrs, visualization) {
         visualizationBuilder.createNewVisualizationData(attrs, visualization)
         visualizationBuilder.buildName()
+        visualizationBuilder.buildCallback()
         visualizationBuilder.buildVersion()
         visualizationBuilder.buildElementId()
         visualizationBuilder.buildDynamicLoading()

--- a/test/unit/org/grails/plugins/google/visualization/GoogleVisualizationBuilderTests.groovy
+++ b/test/unit/org/grails/plugins/google/visualization/GoogleVisualizationBuilderTests.groovy
@@ -54,6 +54,16 @@ class GoogleVisualizationBuilderTests extends GrailsUnitTestCase {
         assertEquals 'visualization', googleVisualizationBuilder.buildName()
     }
 
+    void testBuildCallbackForGivenCallback() {
+        googleVisualizationBuilder.createNewVisualizationData(['callback':'test'], GoogleVisualization.PIE_CHART)
+        assertEquals 'test', googleVisualizationBuilder.buildCallback()
+    }
+
+    void testBuildCallbackForDefaultCallback() {
+        googleVisualizationBuilder.createNewVisualizationData([], GoogleVisualization.PIE_CHART)
+        assertEquals null, googleVisualizationBuilder.buildCallback()
+    }
+
     void testBuildElementId() {
         googleVisualizationBuilder.createNewVisualizationData(['elementId':'someElementId'], GoogleVisualization.PIE_CHART)
         assertEquals 'someElementId', googleVisualizationBuilder.buildElementId()

--- a/test/unit/org/grails/plugins/google/visualization/GoogleVisualizationTagLibTests.groovy
+++ b/test/unit/org/grails/plugins/google/visualization/GoogleVisualizationTagLibTests.groovy
@@ -44,6 +44,34 @@ class GoogleVisualizationTagLibTests extends TagLibUnitTestCase {
         }
     }
 
+    void testRenderApiImportWithoutCallbackAndWithoutKey() {
+        def attrs = []
+        tagLib.apiImport(attrs, "")
+        assertEquals "<script type=\"text/javascript\" src=\"//www.google.com/jsapi\"></script>", tagLib.out.toString()
+    }
+
+    void testRenderApiImportWithCallbackAndWithoutKey() {
+        def attrs = ["callback":"foo"]
+        tagLib.apiImport(attrs, "")
+        assertEquals "<script type=\"text/javascript\" src=\"//www.google.com/jsapi?callback=foo\"></script>", tagLib.out.toString()
+    }
+
+    void testRenderApiImportWithoutCallbackAndWithKey() {
+        def attrs = ["key":"bar"]
+        tagLib.apiImport(attrs, "")
+        assertEquals "<script type=\"text/javascript\" src=\"//www.google.com/jsapi?key=bar\"></script>", tagLib.out.toString()
+    }
+
+    void testRenderApiImportWithCallbackAndWithKey() {
+        def attrs = ["callback":"foo", "key":"bar"]
+        tagLib.apiImport(attrs, "")
+        assertEquals "<script type=\"text/javascript\" src=\"//www.google.com/jsapi?key=bar&callback=foo\"></script>", tagLib.out.toString()
+    }
+
+    void testIsValidAttributeForBasicAttributeCallback() {
+        assertTrue tagLib.isValidAttribute('callback', GoogleVisualization.PIE_CHART)
+    }
+
     void testIsValidAttributeForBasicAttributeName() {
         assertTrue tagLib.isValidAttribute('name', GoogleVisualization.PIE_CHART)
     }

--- a/test/unit/org/grails/plugins/google/visualization/VisualizationDataDirectorTests.groovy
+++ b/test/unit/org/grails/plugins/google/visualization/VisualizationDataDirectorTests.groovy
@@ -41,11 +41,12 @@ class VisualizationDataDirectorTests extends GrailsUnitTestCase {
     }
 
     void testConstructVisualizationData() {
-        def attrs = ['elementId':'piechart', 'title':'My Daily Activities', 'width':400, 'height':240, 'is3D':true, 'columns':[['string', 'Task'], ['number', 'Hours per Day']], 'data':[['Work', 11], ['Eat', 2], ['Commute', 2], ['Watch TV', 2], ['Sleep', 7]], 'select':'selectHandler']
+        def attrs = ['callback':'testcallback', 'elementId':'piechart', 'title':'My Daily Activities', 'width':400, 'height':240, 'is3D':true, 'columns':[['string', 'Task'], ['number', 'Hours per Day']], 'data':[['Work', 11], ['Eat', 2], ['Commute', 2], ['Watch TV', 2], ['Sleep', 7]], 'select':'selectHandler']
         def googleVisualizationBuilder = new GoogleVisualizationBuilder()
         visualizationDataDirector.setVisualizationDataBuilder(googleVisualizationBuilder)
         visualizationDataDirector.constructVisualizationData(attrs, GoogleVisualization.PIE_CHART)
         assertEquals 'visualization', visualizationDataDirector.getVisualizationData().name
+        assertEquals 'testcallback', visualizationDataDirector.getVisualizationData().callback
         assertEquals 'piechart', visualizationDataDirector.getVisualizationData().elementId
         assertEquals "{title: 'My Daily Activities', width: 400, height: 240, is3D: true}", visualizationDataDirector.getVisualizationData().options.toString()
         assertEquals 5, visualizationDataDirector.getVisualizationData().rows.size()


### PR DESCRIPTION
This patch allows you to define a callback for the Google JSAPI. This is helpful when dynamically inserting the output from a GSP into another page, ensuring loading order of the Javascript. This is particularly useful when trying to create all-in-one widgets from various GSP pages that will be inserted elsewhere.

For instance, if you have the following simple GSP:

```
<g:set var="callbackName" value="loadCallback"/>
<gvisualization:apiImport callback="${callbackName}"/>
<gvisualization:geoChart callback="${callbackName}" elementId="chart"  ...  />
<div id="chart"></div>
```

This now will create the following output:

```
<script type="text/javascript" src="//www.google.com/jsapi?callback=loadCallback"></script>
<script type="text/javascript">

    function loadCallback() {
        google.load('visualization', '1', {'packages': ['geochart'], 'callback': drawVisualization});
    }

    function drawVisualization() {
           .... Visualization params and call ....
    }
</script>
<div id="chart"></div>
```

This now explicitly ensures that the JSAPI will load before trying to call google.load.
