### PR TITLE
Fix ObjectRenderer to properly filter class and metaClass properties

### DIFF
--- a/src/groovy/org/grails/plugins/google/visualization/data/renderer/ObjectRenderer.groovy
+++ b/src/groovy/org/grails/plugins/google/visualization/data/renderer/ObjectRenderer.groovy
@@ -29,7 +29,7 @@ class ObjectRenderer implements DataTypeRenderer {
 
         value.properties.each { propertyKey, propertyValue ->
             // Only use class fields
-            if(propertyKey != 'class' || propertyKey != 'metaClass') {
+            if(propertyKey != 'class' && propertyKey != 'metaClass') {
                 objectValues << "${propertyKey}: ${DataTypeValueRenderer.instance.render(propertyValue).value}"
             }
         }


### PR DESCRIPTION
The ObjectRenderer renderValue method doesn't properly filter out class and metaClass properties, because "or" was used where "and" should be used in the filter.  This resulted in a stack overflow when I tried to add a vAxis config to a chart (which requires an object).
