### PR TITLE
Update GoogleVisualizationTagLib.groovy

### DIFF
--- a/grails-app/taglib/org/grails/plugins/google/visualization/GoogleVisualizationTagLib.groovy
+++ b/grails-app/taglib/org/grails/plugins/google/visualization/GoogleVisualizationTagLib.groovy
@@ -26,7 +26,7 @@ class GoogleVisualizationTagLib {
     final BASIC_ATTRIBUTES = ['name', 'version', 'elementId', 'dynamicLoading', 'language', 'columns', 'data'] as Set
 
     def apiImport = { attrs, body ->
-        out << '<script type="text/javascript" src="http://www.google.com/jsapi"></script>'
+        out << '<script type="text/javascript" src="//www.google.com/jsapi"></script>'
     }
 
     def pieChart = { attrs, body ->


### PR DESCRIPTION
Removed http:// from the URL in the src attribute of one script in the apiImport closure, to avoid the "Insecure content message" thrown by the browsers.
