### PR TITLE
Added support for DataView to allow for hiding some of the DataTable columns

### DIFF
--- a/grails-app/taglib/org/grails/plugins/google/visualization/GoogleVisualizationTagLib.groovy
+++ b/grails-app/taglib/org/grails/plugins/google/visualization/GoogleVisualizationTagLib.groovy
@@ -23,7 +23,9 @@ class GoogleVisualizationTagLib {
     static namespace = "gvisualization"
     static final PLUGIN_NAME = 'google-visualization'
     static final VISUALIZATION_JAVASCRIPT_TEMPLATE = '/visualization_javascript'
-    final BASIC_ATTRIBUTES = ['name', 'version', 'elementId', 'dynamicLoading', 'language', 'columns', 'data'] as Set
+
+    //lgarwood - adding dataView as a valid attribute
+    final BASIC_ATTRIBUTES = ['name', 'version', 'elementId', 'dynamicLoading', 'language', 'columns', 'data', 'dataView'] as Set
 
     def apiImport = { attrs, body ->
         out << '<script type="text/javascript" src="https://www.google.com/jsapi"></script>'

--- a/grails-app/views/_visualization_javascript.gsp
+++ b/grails-app/views/_visualization_javascript.gsp
@@ -27,8 +27,17 @@
         <g:each var="beforeDrawEvent" in="${visualizationData.beforeDrawEvents}">
         google.visualization.events.addListener(${visualizationData.name}, '${beforeDrawEvent.key}', ${beforeDrawEvent.value});
         </g:each>
-        
-        ${visualizationData.name}.draw(${visualizationData.name}_data, ${visualizationData.options});
+
+        <g:if test="${visualizationData.dataView}">
+            ${visualizationData.name}_view = new google.visualization.DataView(${visualizationData.name}_data);
+            ${visualizationData.name}_view.setColumns(${visualizationData.dataView});
+            ${visualizationData.name}.draw(${visualizationData.name}_view, ${visualizationData.options});
+        </g:if>
+
+        <g:if test="${visualizationData.dataView == null || visualizationData.dataView?.size() == 0 }">
+            ${visualizationData.name}.draw(${visualizationData.name}_data, ${visualizationData.options});
+        </g:if>
+
 
         <g:each var="afterDrawEvent" in="${visualizationData.afterDrawEvents}">
         google.visualization.events.addListener(${visualizationData.name}, '${afterDrawEvent.key}', ${afterDrawEvent.value});

--- a/src/main/groovy/org/grails/plugins/google/visualization/GoogleVisualizationBuilder.groovy
+++ b/src/main/groovy/org/grails/plugins/google/visualization/GoogleVisualizationBuilder.groovy
@@ -207,4 +207,9 @@ class GoogleVisualizationBuilder extends VisualizationBuilder {
     def buildFormatters() {
         visualizationData.formatters = attrs.formatters 
     }
+
+    @Override
+    def buildDataView() {
+        visualizationData.dataView = attrs.dataView
+    }
 }


### PR DESCRIPTION
I need to have ID's associated with my graphing data for navigations purposes,  I did not want this data to show on my chart.  I added support to the taglib for using the google visualization DataView to accomodate this.